### PR TITLE
Correction de la Logique de Confirmation du Mot de Passe dans le Formulaire d'Inscription

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,7 @@ const SignupPage = () => {
     event.preventDefault();
 
     // Validation des champs
-    if (!email || !password || password === confirmPassword) {
+    if (!email || !password || password !== confirmPassword) {
       setErrorMessage('Veuillez remplir tous les champs correctement');
       return;
     }


### PR DESCRIPTION

Dans la partie du code qui gère la soumission du formulaire (handleSubmit), j'ai modifié la condition de validation du mot de passe. Au lieu de vérifier si le mot de passe et la confirmation du mot de passe sont différents (password !== confirmPassword), la condition modifiée vérifie s'ils sont identiques (password === confirmPassword). Cette erreur va provoquer l'affichage d'un message d'erreur même lorsque les mots de passe correspondent, ce qui n'est pas le comportement attendu. Il s'agit d'une erreur logique plutôt que syntaxique, ce qui la rend un peu plus difficile à détecter, idéal pour un tutoriel sur les pull requests.